### PR TITLE
Fix typo in [.README/Corrected a Small Typo]

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ dnsdumpster:
   - zsdqYb0rvIVYh2uPHo5Yk4EljV9GEKn44hDL9V2DFXznflW37Q5pZl8pvQHUHWav:Z488EzyPXVwDAhDGlm8gTBvkubRfLyBxuTytPjA17aa2yA5ULO8HySZoG6ptOKoY
 
 ```
-Booyah ⚡ completed , now you can run `subdominator` with its maxiumum and wait for 2-4 minutes then you will have your results.
+Booyah ⚡ completed , now you can run `subdominator` with its maximum and wait for 2-4 minutes then you will have your results.
 
 ### Security:
 


### PR DESCRIPTION
![typoooo](https://github.com/user-attachments/assets/602c9df5-8e74-4323-807e-72e456db4696)

I hope this finds you wel,
**Even though it was not a big thing boss. but  why do a perfect tool docs contain a small typoo**
So i fixed it ..
Thank youhhh