### PR TITLE
fix(install): add dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Requests>=2.31.0
 rich>=13.7.1
 urllib3>=1.26.18
 tldextract>=5.1.2
+colorama>=0.4.6

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
         'Requests>=2.31.0',
         'rich>=13.7.1',
         'urllib3>=1.26.18',
-        'tldextract>=5.1.2'
+        'tldextract>=5.1.2',
+        'colorama>=0.4.6'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Hi,

I have add colorama dependencies because is not installed in `setup.py` or `requirements.txt`.
Colorama is installed manualy on Dockerfile.

Regards